### PR TITLE
Declare dependency on ploperations/rack

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ source 'https://github.com/puppetlabs-operations/puppet-unicorn'
 project_page 'https://github.com/puppetlabs-operations/puppet-unicorn'
 
 dependency 'ploperations/bundler',      '>= 0.0.1'
+dependency 'ploperations/rack',         '>= 0.0.1'


### PR DESCRIPTION
The `unicorn` module utilizes the `rack` class from `ploperations/rack` so it should declare this dependency in its `Modulefile`.

See puppetlabs-operations/puppet-rack#1 for a related pull request.
