### PR TITLE
Set the HOME environment variable

### DIFF
--- a/templates/config_unicorn.config.rb.erb
+++ b/templates/config_unicorn.config.rb.erb
@@ -38,6 +38,7 @@ after_fork do |server, worker|
     group = '<%= @group %>'
     target_uid = Etc.getpwnam(user).uid
     target_gid = Etc.getgrnam(group).gid
+    ENV['HOME'] = Etc.getpwuid(target_uid).dir
     worker.tmp.chown(target_uid, target_gid)
     if uid != target_uid || gid != target_gid
       Process.initgroups(user, target_gid)


### PR DESCRIPTION
Previously, the HOME variable was not in the environment at all.

Here we set the HOME environment variable to ensure that anything being
run under unicorn will have the correct environment for the target user.
