### PR TITLE
Add ability to manage service external to this puppet-unicorn module

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -56,16 +56,6 @@ define unicorn::app (
     }
   }
 
-  service { "unicorn_${name}":
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    start      => "${rc_d}/unicorn_${name} start",
-    stop       => "${rc_d}/unicorn_${name} stop",
-    restart    => "${rc_d}/unicorn_${name} reload",
-    require    => File["${rc_d}/unicorn_${name}"],
-  }
-
   if $unicorn::params::etc_default {
     file { "/etc/default/unicorn_${name}":
       owner   => 'root',
@@ -78,6 +68,16 @@ define unicorn::app (
   }
 
   if $manage_service {
+    service { "unicorn_${name}":
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      start      => "${rc_d}/unicorn_${name} start",
+      stop       => "${rc_d}/unicorn_${name} stop",
+      restart    => "${rc_d}/unicorn_${name} reload",
+      require    => File["${rc_d}/unicorn_${name}"],
+    }
+
     file { "${rc_d}/unicorn_${name}":
       owner   => 'root',
       group   => '0',

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -2,17 +2,18 @@ define unicorn::app (
   $approot,
   $pidfile,
   $socket,
-  $backlog         = '2048',
-  $workers         = $::processorcount,
-  $user            = 'root',
-  $group           = '0',
-  $config_file     = '',
-  $config_template = 'unicorn/config_unicorn.config.rb.erb',
-  $initscript      = undef,
-  $logdir          = "${approot}/log",
-  $rack_env        = 'production',
-  $preload_app     = false,
-  $source          = 'system',
+  $backlog            = '2048',
+  $workers            = $::processorcount,
+  $user               = 'root',
+  $group              = '0',
+  $config_file        = '',
+  $config_template    = 'unicorn/config_unicorn.config.rb.erb',
+  $initscript         = undef,
+  $manage_service     = true,
+  $logdir             = "${approot}/log",
+  $rack_env           = 'production',
+  $preload_app        = false,
+  $source             = 'system',
 ) {
 
   require unicorn
@@ -76,12 +77,14 @@ define unicorn::app (
     }
   }
 
-  file { "${rc_d}/unicorn_${name}":
-    owner   => 'root',
-    group   => '0',
-    mode    => '0755',
-    content => template($real_initscript),
-    notify  => Service["unicorn_${name}"],
+  if $manage_service {
+    file { "${rc_d}/unicorn_${name}":
+      owner   => 'root',
+      group   => '0',
+      mode    => '0755',
+      content => template($real_initscript),
+      notify  => Service["unicorn_${name}"],
+    }
   }
 
   file { $config:

--- a/templates/config_unicorn.config.rb.erb
+++ b/templates/config_unicorn.config.rb.erb
@@ -1,5 +1,7 @@
 # This is the configuration for running apps with unicorn.
 # See original here: http://projects.puppetlabs.com/projects/1/wiki/Using_Unicorn
+RACK_ENV = ENV['RACK_ENV'] ||= 'development'  unless defined?(RACK_ENV)
+RAILS_ENV = ENV['RAILS_ENV'] ||= 'development'  unless defined?(RAILS_ENV)
 
 worker_processes <%= @workers %>
 working_directory '<%= @approot %>'


### PR DESCRIPTION
This allows us to use pleaserun or similar to create init scripts & manage the server, allowing us to run on CentOS though in theory could work for SuSe or any other platform.