### PR TITLE
Make the 'reload' action of the init script call 'start' if PIDFILE doesn't contain a PID.

### DIFF
--- a/templates/init-unicorn.erb
+++ b/templates/init-unicorn.erb
@@ -51,26 +51,31 @@ restart() {
 # failed; if it's dead, the reload succeeded.
 #
 reload() {
-    log_daemon_msg "Reloading Unicorn master and worker processes" <%= @name %>
+    oldpid=$(cat $PIDFILE 2> /dev/null)
 
-    oldpid=$(cat $PIDFILE)
-    start-stop-daemon --stop --quiet --signal USR2 --pidfile $PIDFILE
+    if [ -z $oldpid ]; then
+      # It appears unicorn was not already running, so just start it.
+      start
+    else
+      log_daemon_msg "Reloading Unicorn master and worker processes" <%= @name %>
+      start-stop-daemon --stop --quiet --signal USR2 --pidfile $PIDFILE
 
-    RETVAL=1
+      RETVAL=1
 
-    # Recheck the old unicorn master process times to see if it's exited, and
-    # return as soon as it has exited.
-    for second in {1..<%= @init_time %>}; do
-        sleep 1
-        kill -0 $oldpid 2>/dev/null 1>/dev/null
-        if [ $? -eq '1' ]; then
-            RETVAL=0
-            break
-        fi
-    done
+      # Recheck the old unicorn master process times to see if it's exited, and
+      # return as soon as it has exited.
+      for second in {1..<%= @init_time %>}; do
+          sleep 1
+          kill -0 $oldpid 2>/dev/null 1>/dev/null
+          if [ $? -eq '1' ]; then
+              RETVAL=0
+              break
+          fi
+      done
 
-    log_end_msg $RETVAL
-}
+      log_end_msg $RETVAL
+    fi
+  }
 
 reopen_logs() {
     log_daemon_msg "Reopening Unicorn logs" <%= @name %>


### PR DESCRIPTION
This makes it safe to call 'reload' action regardless of whether or not the Unicorn app is currently running.
