### PR TITLE
`empty?` doesn't work on Nil

### DIFF
--- a/templates/init-unicorn.erb
+++ b/templates/init-unicorn.erb
@@ -24,7 +24,7 @@ RETVAL=0
 
 . /lib/lsb/init-functions
 
-<% unless (@export_home.empty?) %>
+<% unless (@export_home.nil?) %>
 # Force a HOME environment
 # Needed for a puppet master running on unicorn
 export HOME=<%= @export_home %>


### PR DESCRIPTION
You run into this if you don't use puppet to install unicorn.
