### PR TITLE
Add $export_home parameter to unicorn::app

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -2,6 +2,7 @@ define unicorn::app (
   $approot,
   $pidfile,
   $socket,
+  $export_home     = '',
   $backlog         = '2048',
   $workers         = $::processorcount,
   $user            = 'root',


### PR DESCRIPTION
Adds ability to export HOME in init scripts configured via unicorn::app rather than ::unicorn
Needed for puppet-puppet's unicorn server functionality; this should have been included in PR https://github.com/puppetlabs-operations/puppet-unicorn/pull/14. I'll update puppet-puppet to use this once this PR is accepted.
