### PR TITLE
Add Ubuntu support to params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,11 @@ class unicorn::params {
         }
       }
     }
+    'ubuntu': {
+      $unicorn_executable = '/usr/local/bin/unicorn'
+      $bundler_executable = '/usr/local/bin/bundle'
+    }
+
     'freebsd': {
       $unicorn_executable = '/usr/local/bin/unicorn'
       $bundler_executable = '/usr/local/bin/bundle'


### PR DESCRIPTION
Previous to this commit, if the module was used on an Ubuntu system, the
path to the unicorn executables were not entered into the
/etc/defaults/unicorn_<app> file causing the init script to not be able
to launch the app.  This commit adds the path to the Ubuntu executables
to the params.pp file
