### PR TITLE
Use long options parameters for unicorn command

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -37,7 +37,7 @@ define unicorn::app (
     $config = $config_file
   }
 
-  $unicorn_opts = "-D -E ${rack_env} -c ${config}"
+  $unicorn_opts = "--daemonize --env ${rack_env} --config-file ${config}"
   # XXX Debian Wheezy specific
   case $source {
     'system': {


### PR DESCRIPTION
They are more readable and more memorable. This is how shell scripts can be self-documented.
