### PR TITLE
systemd, custom unicorn paths, and an updated config

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -49,7 +49,8 @@ define unicorn::app (
       $daemon      = $unicorn::params::bundler_executable
       $daemon_opts = "exec unicorn ${unicorn_opts}"
     }
-    /\/bin\/unicorn$/: {
+    /[a-z]/: {
+      # A path to an executable
       $daemon      = $source
       $daemon_opts = $unicorn_opts
     }

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -6,7 +6,7 @@ define unicorn::app (
   $backlog         = '2048',
   $workers         = $::processorcount,
   $user            = 'root',
-  $group           = '0',
+  $group           = 'root',
   $config_file     = '',
   $config_template = 'unicorn/config_unicorn.config.rb.erb',
   $initscript      = undef,

--- a/templates/config_unicorn.config.rb.erb
+++ b/templates/config_unicorn.config.rb.erb
@@ -1,12 +1,13 @@
-# This is the configuration for running apps with unicorn.
-# See original here: http://projects.puppetlabs.com/projects/1/wiki/Using_Unicorn
+# This file is managed by Puppet. Changes will be overwritten.
 
 worker_processes <%= @workers %>
 working_directory '<%= @approot %>'
 listen '<%= @socket %>', :backlog => <%= @backlog %>
 timeout 300
-pid "<%= @pidfile %>"
 client_body_buffer_size 524288
+
+pid "<%= @pidfile %>"
+user '<%= @user %>', '<%= @group %>'
 
 <% if @logdir -%>
 stderr_path '<%= @logdir %>/stderr.log'
@@ -14,43 +15,3 @@ stdout_path '<%= @logdir %>/stdout.log'
 <% end -%>
 
 preload_app <%= @preload_app %>
-
-# See http://unicorn.bogomips.org/SIGNALS.html for what this does.
-before_fork do |server, worker|
-  old_pid = "#{server.config[:pid]}.oldbin"
-  if File.exists?(old_pid) && server.pid != old_pid
-    begin
-      Process.kill("QUIT", File.read(old_pid).to_i)
-    rescue Errno::ENOENT, Errno::ESRCH
-      # someone else did our job for us
-    end
-  end
-end
-
-
-<% if (@user and @user != 'root') and (@group and @group != 'root') -%>
-# Stolen from https://github.com/blog/517-unicorn
-after_fork do |server, worker|
-
-  begin
-    uid, gid = Process.euid, Process.egid
-    user  = '<%= @user %>'
-    group = '<%= @group %>'
-    target_uid = Etc.getpwnam(user).uid
-    target_gid = Etc.getgrnam(group).gid
-    ENV['HOME'] = Etc.getpwuid(target_uid).dir
-    worker.tmp.chown(target_uid, target_gid)
-    if uid != target_uid || gid != target_gid
-      Process.initgroups(user, target_gid)
-      Process::GID.change_privilege(target_gid)
-      Process::UID.change_privilege(target_uid)
-    end
-  rescue => e
-    if RAILS_ENV == 'development'
-      STDERR.puts "couldn't change user, oh well"
-    else
-      raise e
-    end
-  end
-end
-<% end -%>

--- a/templates/systemd/unicorn.service.erb
+++ b/templates/systemd/unicorn.service.erb
@@ -1,0 +1,24 @@
+# Managed by Puppet. Changes will be overwritten.
+
+[Unit]
+Description=Unicorn for <%= @name %>
+After=syslog.target
+After=network.target
+
+[Service]
+Type=forking
+Restart=always
+WorkingDirectory=<%= @approot %>
+PIDFile=<%= @pidfile %>
+
+Environment="RAILS_ENV=<%= @rack_env %>"
+Environment="RACK_ENV=<%= @rack_env %>"
+<% @extra_settings.sort.each do |variable, setting| -%>
+Environment="<%= variable %>=<%= setting %>"
+<% end -%>
+
+ExecStart=<%= @daemon %> <%= @daemon_opts %>
+KillSignal=SIGQUIT
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Sorry to batch these together.

* This now supports `systemd`.
* Any path may be specified for the `unicorn` executable, not just ones ending in `/bin/unicorn`.
* The configuration file has been updated to use standard `unicorn` settings rather than hacks.