### PR TITLE
Option to not manage package, ::rack, and ::ruby::dev

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,17 @@
-class unicorn(
+class unicorn (
   $export_home = '',
+  $manage_package = true,
   $ensure   = 'present',
   $provider = 'gem',
 ) {
+  if $manage_package {
+    # The unicorn gem has prerequisites that requires building native extensions.
+    require ::ruby::dev
+    include ::rack
 
-  # The unicorn gem has prerequisites that requires building native extensions.
-  require ruby::dev
-  include rack
-
-  package { 'unicorn':
-    ensure   => $ensure,
-    provider => $provider,
+    package { 'unicorn':
+      ensure   => $ensure,
+      provider => $provider,
+    }
   }
 }


### PR DESCRIPTION
This is particularly useful if you are installing unicorn with rvm or similar.