### PR TITLE
(MAINT) Export 'extra_settings' variables in /etc/default file

### DIFF
--- a/templates/default-unicorn.erb
+++ b/templates/default-unicorn.erb
@@ -18,5 +18,5 @@ export RAILS_ENV="$ENV"
 export RACK_ENV="$ENV"
 
 <% @extra_settings.sort.each do |variable, setting| -%>
-<%= variable.to_s %>="<%= setting.to_s %>"
+export <%= variable.to_s %>="<%= setting.to_s %>"
 <% end -%>


### PR DESCRIPTION
Updates the managed /etc/default/* file for each unicorn application to
'export' any env vars set via the 'extra_settings' param so that those
vars are available to the underlying application. Otherwise the vars are
only available in the context of the init script.