### PR TITLE
(PF-1605) Add Unicorn reload action to templated systemd unit

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -60,14 +60,18 @@ define unicorn::app (
   }
 
   if $facts['service_provider'] == 'systemd' {
+    include systemd::systemctl::daemon_reload
+
     file { "/etc/systemd/system/unicorn_${name}.service":
       owner   => 'root',
       group   => '0',
       mode    => '0644',
       content => template('unicorn/systemd/unicorn.service.erb'),
     }
-    ~>
-    service { "unicorn_${name}":
+
+    ~> Class['systemd::systemctl::daemon_reload']
+
+    ~> service { "unicorn_${name}":
       ensure => running,
       enable => true,
     }

--- a/templates/systemd/unicorn.service.erb
+++ b/templates/systemd/unicorn.service.erb
@@ -18,6 +18,7 @@ Environment="<%= variable %>=<%= setting %>"
 <% end -%>
 
 ExecStart=<%= @daemon %> <%= @daemon_opts %>
+ExecReload=/bin/kill -s USR2 $MAINPID
 KillSignal=SIGQUIT
 
 [Install]


### PR DESCRIPTION
Adds support for Unicorn's SIGUSR2 based 0-downtime restart action, implemented as a "reload" for systemctl.